### PR TITLE
fix: eliminate redundant BERT model loads and hf_hub API calls

### DIFF
--- a/src/ml/embedding.rs
+++ b/src/ml/embedding.rs
@@ -13,8 +13,29 @@ use candle_core::{Device, Tensor};
 use candle_transformers::models::bert::{BertModel, Config as BertConfig};
 use chrono;
 use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
 
 use serde::{Deserialize, Serialize};
+
+/// Heavy BERT components cached process-wide.
+/// `BertModel::forward()` takes `&self`, so sharing via `Arc` is safe.
+#[allow(dead_code)] // fields read in non-test builds only
+struct SharedBertModel {
+    bert_model: BertModel,
+    device: Device,
+    /// Path to model files on disk (for loading tokenizer on reuse path)
+    model_dir: PathBuf,
+}
+
+// SAFETY: BertModel contains only Tensors (Arc-backed), Device, and tracing::Span —
+// all of which are Send + Sync.
+unsafe impl Send for SharedBertModel {}
+unsafe impl Sync for SharedBertModel {}
+
+/// Process-wide singleton for the loaded BERT model.
+/// Set on first successful init; subsequent `EmbeddingModel::new()` calls reuse it.
+static SHARED_BERT: OnceLock<Arc<SharedBertModel>> = OnceLock::new();
 
 /// Configuration for embedding model
 #[derive(Debug, Clone)]
@@ -52,7 +73,7 @@ pub struct EmbeddingModel {
     config: EmbeddingConfig,
     /// Text processor for tokenization
     text_processor: TextProcessor,
-    /// Embedding cache for performance
+    /// Embedding cache for performance (per-instance, no contention)
     cache: HashMap<String, Embedding>,
     /// Model manager for loading models
     model_manager: ModelManager,
@@ -60,25 +81,58 @@ pub struct EmbeddingModel {
     is_ready: bool,
     /// Candle device for computation
     device: Device,
-    /// BERT model for inference
+    /// BERT model for inference (only set on first process-wide init, then moved to SHARED_BERT)
     bert_model: Option<BertModel>,
+    /// Shared reference to the process-wide BERT model singleton
+    shared_bert: Option<Arc<SharedBertModel>>,
 }
 
 impl EmbeddingModel {
-    /// Create new embedding model with real Candle inference
+    /// Create new embedding model with real Candle inference.
+    ///
+    /// On the first call in a process, downloads (if needed) and loads the full BERT model
+    /// (~300ms). Subsequent calls reuse the cached model via a process-wide singleton,
+    /// only re-loading the lightweight tokenizer from disk.
     pub async fn new(config: EmbeddingConfig) -> Result<Self> {
-        log::info!("Initializing real embedding model: {}", config.model_name);
+        // Fast path: reuse the process-wide cached BERT model
+        if let Some(shared) = SHARED_BERT.get() {
+            log::info!(
+                "Reusing cached BERT model from {}",
+                shared.model_dir.display()
+            );
 
+            let text_config = TextConfig {
+                max_length: config.max_length,
+                ..Default::default()
+            };
+            let mut text_processor = TextProcessor::new(text_config);
+            if let Err(e) = text_processor.load_tokenizer(&shared.model_dir) {
+                log::warn!("Failed to load tokenizer from cached path: {}", e);
+            }
+
+            let model_manager = ModelManager::new(None)?;
+
+            return Ok(Self {
+                config,
+                text_processor,
+                cache: HashMap::new(),
+                model_manager,
+                is_ready: true,
+                device: shared.device.clone(),
+                bert_model: None,
+                shared_bert: Some(Arc::clone(shared)),
+            });
+        }
+
+        // Slow path: first initialization in this process
+        log::info!("Initializing embedding model: {}", config.model_name);
         log::info!("Using device: {:?}", config.device_type);
 
-        // Initialize text processor
         let text_config = TextConfig {
             max_length: config.max_length,
             ..Default::default()
         };
         let text_processor = TextProcessor::new(text_config);
-
-        // Initialize model manager
         let model_manager = ModelManager::new(None)?;
 
         let mut embedding_model = Self {
@@ -89,11 +143,32 @@ impl EmbeddingModel {
             is_ready: false,
             device: Device::Cpu,
             bert_model: None,
+            shared_bert: None,
         };
 
         // Try to load the model
         if let Err(e) = embedding_model.load_model().await {
             log::warn!("Failed to load model, will use fallback: {}", e);
+        }
+
+        // Cache the loaded model in the process-wide singleton for future reuse
+        if embedding_model.is_ready {
+            if let Some(bert) = embedding_model.bert_model.take() {
+                let model_dir = embedding_model
+                    .model_manager
+                    .get_model(&embedding_model.config.model_name)
+                    .and_then(|m| m.local_path.clone())
+                    .unwrap_or_default();
+
+                let shared = Arc::new(SharedBertModel {
+                    bert_model: bert,
+                    device: embedding_model.device.clone(),
+                    model_dir,
+                });
+                // If another thread raced us, ignore the error — we still hold a valid Arc
+                let _ = SHARED_BERT.set(Arc::clone(&shared));
+                embedding_model.shared_bert = Some(shared);
+            }
         }
 
         Ok(embedding_model)
@@ -254,10 +329,12 @@ impl EmbeddingModel {
                 tokenized.input_ids.len()
             );
 
-            // Get BERT model reference
+            // Get BERT model reference (prefer shared singleton, fall back to local)
             let bert_model = self
-                .bert_model
+                .shared_bert
                 .as_ref()
+                .map(|s| &s.bert_model)
+                .or(self.bert_model.as_ref())
                 .ok_or_else(|| MemvidError::MachineLearning("BERT model not loaded".to_string()))?;
 
             // Convert to tensors on the correct device
@@ -365,7 +442,9 @@ impl EmbeddingModel {
             return Ok(cached.clone());
         }
 
-        let embedding = if self.is_ready && self.bert_model.is_some() {
+        let embedding = if self.is_ready
+            && (self.bert_model.is_some() || self.shared_bert.is_some())
+        {
             // Use TRUE BERT neural network inference
             log::debug!("🧠 Generating TRUE BERT embedding for: {}", text);
             self.generate_bert_embedding(text)?

--- a/src/ml/models.rs
+++ b/src/ml/models.rs
@@ -82,16 +82,38 @@ impl ModelManager {
 
     /// Register default models
     fn register_default_models(&mut self) -> Result<()> {
-        // Register all-MiniLM-L6-v2 model
+        // Pre-check if models already exist on disk to avoid unnecessary hf_hub API calls.
+        // download_model() stores files at cache_dir.join(name), so check both the full
+        // hub_id path (common case) and the short name path.
+        let mini_lm_full_dir = self
+            .cache_dir
+            .join("sentence-transformers/all-MiniLM-L6-v2");
+        let mini_lm_short_dir = self.cache_dir.join("all-MiniLM-L6-v2");
+        let (mini_lm_cached, mini_lm_dir) =
+            if Self::validate_model_files_static(&mini_lm_full_dir).unwrap_or(false) {
+                (true, Some(mini_lm_full_dir))
+            } else if Self::validate_model_files_static(&mini_lm_short_dir).unwrap_or(false) {
+                (true, Some(mini_lm_short_dir))
+            } else {
+                (false, None)
+            };
+
+        if mini_lm_cached {
+            log::debug!(
+                "all-MiniLM-L6-v2 pre-cached at {:?}",
+                mini_lm_dir.as_ref().unwrap()
+            );
+        }
+
         let mini_lm = ModelInfo {
             name: "all-MiniLM-L6-v2".to_string(),
             model_type: ModelType::SentenceTransformer,
-            local_path: None,
+            local_path: mini_lm_dir,
             hub_id: Some("sentence-transformers/all-MiniLM-L6-v2".to_string()),
             config: ModelConfig {
                 dimension: 384,
                 max_length: 384,
-                cached: false,
+                cached: mini_lm_cached,
                 params: HashMap::new(),
             },
         };
@@ -105,15 +127,18 @@ impl ModelManager {
         );
 
         // Register other common models
+        let bert_dir = self.cache_dir.join("bert-base-uncased");
+        let bert_cached = Self::validate_model_files_static(&bert_dir).unwrap_or(false);
+
         let bert_base = ModelInfo {
             name: "bert-base-uncased".to_string(),
             model_type: ModelType::Bert,
-            local_path: None,
+            local_path: if bert_cached { Some(bert_dir) } else { None },
             hub_id: Some("bert-base-uncased".to_string()),
             config: ModelConfig {
                 dimension: 768,
                 max_length: 512,
-                cached: false,
+                cached: bert_cached,
                 params: HashMap::new(),
             },
         };


### PR DESCRIPTION
## Summary

- **Pre-populate model cache paths on startup**: `register_default_models()` now checks if model files already exist on disk before registering. When cached, `download_model()` hits its early-return path without ever calling `hf_hub::Api::new()`, eliminating 5x "Token file not found" warnings per init.
- **Process-level BERT model singleton**: Adds `OnceLock<Arc<SharedBertModel>>` so the ~300ms BERT weight loading only happens once per process. Subsequent `EmbeddingModel::new()` calls reuse the cached model, only re-loading the lightweight tokenizer from disk.

## Motivation

When using memvid-rs for conversation memory (e.g. from a Tauri app), each message cycle creates 2-3 `EmbeddingModel` instances (retriever → encoder → retriever refresh). Each init redundantly:
1. Loads BERT weights from disk (~300ms)
2. Calls `hf_hub::Api::new()` per model file even when already cached (5 calls → 5 "Token file not found" warnings)

This PR saves ~600ms per cycle and eliminates all HuggingFace log noise when the model is cached.

## Changes

| File | Change |
|------|--------|
| `src/ml/models.rs` | Pre-populate `local_path`/`cached` in `register_default_models()` when model files exist on disk |
| `src/ml/embedding.rs` | Add `SharedBertModel` + `OnceLock` singleton; fast-path in `new()`; update `encode()`/`generate_bert_embedding()` to prefer shared model |

## Test plan

- [x] `cargo check` — no warnings
- [x] `cargo test --lib` — all 112 unit tests pass
- [x] Integration tests pass (except `llm_integration_benchmark` which requires a live LLM server)
- [ ] Manual verification: first `EmbeddingModel::new()` logs "Loading BERT model..."; subsequent calls log "Reusing cached BERT model"

🤖 Generated with [Claude Code](https://claude.com/claude-code)