### PR TITLE
chore: upgrade ffmpeg-next from 7.1 to 8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -360,7 +360,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "7.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
 dependencies = [
  "bitflags 2.9.1",
  "ffmpeg-sys-next",
@@ -1269,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "7.1.3"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
 dependencies = [
  "bindgen",
  "cc",
@@ -3440,7 +3440,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.12",
@@ -3460,7 +3460,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3860,12 +3860,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ image = "0.25"   # Pure Rust image processing
 imageproc = "0.25"  # Additional image processing algorithms
 
 # Video processing - Static FFmpeg for all formats
-ffmpeg-next = "7.1"  # Static FFmpeg - handles everything
+ffmpeg-next = "8.0"  # Static FFmpeg - handles everything
 
 # Machine learning and embedding models - COMPLETE ML STACK
 candle-core = "0.8"  # Base candle support, GPU features added conditionally


### PR DESCRIPTION
## Summary

- Bumps `ffmpeg-next` from `7.1` to `8.0` (and `ffmpeg-sys-next` from `7.1.3` to `8.0.1`)
- **Zero source code changes** — memvid-rs uses only stable high-level APIs (encoder, decoder, swscale) that are unchanged in FFmpeg 8.x

## Motivation

Users currently need to install FFmpeg 7.x specifically (`brew install ffmpeg@7` + manual path setup). With this upgrade, `brew install ffmpeg` (which gives 8.x) works out of the box, removing a friction point for new contributors.

The `avfft.h` removal in FFmpeg 8.x — previously cited as the blocker — does not affect memvid-rs since no FFT functions are used anywhere in the codebase.

## Test plan

- [x] `cargo check` — zero errors, zero warnings
- [x] `cargo test --lib` — all 114 unit tests pass
- [x] Integration tests pass (basic_encoding, cli_append_test, incremental_update_demo, llm_integration_benchmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)